### PR TITLE
(maint) Do not provision boost on OS X

### DIFF
--- a/configs/platforms/osx-10.14-x86_64.rb
+++ b/configs/platforms/osx-10.14-x86_64.rb
@@ -16,8 +16,6 @@ platform 'osx-10.14-x86_64' do |plat|
   plat.provision_with 'cd /etc/homebrew'
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/'
-  packages = ['boost@1.60']
-  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
   plat.vmpooler_template 'osx-1014-x86_64'
   plat.output_dir File.join('apple', '10.14', 'puppet7', 'x86_64')
 end

--- a/configs/platforms/osx-10.15-x86_64.rb
+++ b/configs/platforms/osx-10.15-x86_64.rb
@@ -16,8 +16,6 @@ platform 'osx-10.15-x86_64' do |plat|
   plat.provision_with 'cd /etc/homebrew'
   plat.provision_with 'su test -c \'echo | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/'
-  packages = ['boost@1.60']
-  plat.provision_with "su test -c '/usr/local/bin/brew install #{packages.join(' ')}'"
   plat.vmpooler_template 'osx-1015-x86_64'
   plat.output_dir File.join('apple', '10.15', 'puppet7', 'x86_64')
 end


### PR DESCRIPTION
Boost already comes in puppet-runtime, we shouldn't need to install it.