### PR TITLE
Add debian-10-armhf to pxp-agent

### DIFF
--- a/configs/platforms/debian-10-armhf.rb
+++ b/configs/platforms/debian-10-armhf.rb
@@ -1,0 +1,10 @@
+platform 'debian-10-armhf' do |plat|
+  plat.servicedir '/lib/systemd/system'
+  plat.defaultdir '/etc/default'
+  plat.servicetype 'systemd'
+  plat.codename 'buster'
+  packages = %w[build-essential devscripts make quilt pkg-config debhelper rsync fakeroot cmake]
+  plat.provision_with "export DEBIAN_FRONTEND=noninteractive; apt-get update -qq; apt-get install -qy --no-install-recommends #{packages.join(' ')}"
+  plat.install_build_dependencies_with 'DEBIAN_FRONTEND=noninteractive; apt-get install -qy --no-install-recommends '
+  plat.vmpooler_template 'debian-10-armhf'
+end


### PR DESCRIPTION
This comit adds debian-10-armhf platform as a direct compile.

This requires https://github.com/puppetlabs/puppet-runtime/pull/420 first.