### PR TITLE
(VANAGON-85) remove duplicate systemd on debian 9

### DIFF
--- a/configs/platforms/debian-9-amd64.rb
+++ b/configs/platforms/debian-9-amd64.rb
@@ -1,6 +1,5 @@
 platform "debian-9-amd64" do |plat|
   plat.inherit_from_default
 
-  plat.servicetype 'systemd', servicedir: '/lib/systemd/system'
   plat.servicetype 'sysv', servicedir: '/etc/init.d'
 end

--- a/configs/platforms/debian-9-i386.rb
+++ b/configs/platforms/debian-9-i386.rb
@@ -1,6 +1,5 @@
 platform "debian-9-i386" do |plat|
   plat.inherit_from_default
 
-  plat.servicetype 'systemd', servicedir: '/lib/systemd/system'
   plat.servicetype 'sysv', servicedir: '/etc/init.d'
 end


### PR DESCRIPTION
Vanagon already defines systemd in the default
platform definition. Remove it from here to avoid
duplication.