### PR TITLE
(PA-3829) Add macOS 11 arm64 platform

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -13,6 +13,7 @@ component 'cpp-hocon' do |pkg, settings, platform|
     cmake = '/usr/local/bin/cmake'
     boost_static_flag = '-DBOOST_STATIC=OFF'
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
+    pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.is_cross_compiled?
   elsif platform.is_cross_compiled_linux?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = '/opt/pl-build-tools/bin/cmake'
@@ -69,7 +70,11 @@ component 'cpp-hocon' do |pkg, settings, platform|
   # Make test will explode horribly in a cross-compile situation
   # Tests will be skipped on AIX until they are expected to pass
   test = if platform.is_cross_compiled? || platform.is_aix?
-           '/bin/true'
+           if platform.is_macos?
+             '/usr/bin/true'
+           else
+             '/bin/true'
+           end
          else
            "#{make} test ARGS=-V"
          end

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -29,6 +29,7 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     toolchain = ''
     boost_static_flag = '-DBOOST_STATIC=OFF'
+    pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.is_cross_compiled?
   elsif platform.is_cross_compiled_linux?
     cmake = '/opt/pl-build-tools/bin/cmake'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -39,6 +39,7 @@ component 'leatherman' do |pkg, settings, platform|
     cmake = '/usr/local/bin/cmake'
     boost_static_flag = '-DBOOST_STATIC=OFF'
     special_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF -DLEATHERMAN_MOCK_CURL=FALSE"
+    pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.is_cross_compiled?
   elsif platform.is_cross_compiled_linux?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -33,6 +33,7 @@ component 'pxp-agent' do |pkg, settings, platform|
     toolchain = ''
     special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
     boost_static_flag = '-DBOOST_STATIC=OFF'
+    pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.is_cross_compiled?
   elsif platform.is_cross_compiled_linux?
     cmake = '/opt/pl-build-tools/bin/cmake'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/platforms/osx-11-arm64.rb
+++ b/configs/platforms/osx-11-arm64.rb
@@ -1,0 +1,22 @@
+platform "osx-11-arm64" do |plat|
+  plat.servicetype "launchd"
+  plat.servicedir "/Library/LaunchDaemons"
+  plat.codename "bigsur"
+  plat.provision_with "export HOMEBREW_NO_EMOJI=true"
+  plat.provision_with "export HOMEBREW_VERBOSE=true"
+  plat.provision_with "sudo dscl . -create /Users/test"
+  plat.provision_with "sudo dscl . -create /Users/test UserShell /bin/bash"
+  plat.provision_with "sudo dscl . -create /Users/test UniqueID 1001"
+  plat.provision_with "sudo dscl . -create /Users/test PrimaryGroupID 1000"
+  plat.provision_with "sudo dscl . -create /Users/test NFSHomeDirectory /Users/test"
+  plat.provision_with "sudo dscl . -passwd /Users/test password"
+  plat.provision_with "sudo dscl . -merge /Groups/admin GroupMembership test"
+  plat.provision_with "echo 'test ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/username"
+  plat.provision_with "mkdir -p /etc/homebrew"
+  plat.provision_with "cd /etc/homebrew"
+  plat.provision_with %(su test -c 'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"')
+  plat.provision_with "sudo chown -R test:admin /Users/test/"
+  plat.vmpooler_template "macos-112-x86_64"
+  plat.cross_compiled true
+  plat.output_dir File.join('apple', '11', 'PC1', 'arm64')
+end


### PR DESCRIPTION
Add support for building the pxp-agent project for macOS 11 ARM64 (M1) via cross-compilation from an x86 host.