### PR TITLE
Revert "(maint) Update leatherman to 5a63a79f8358647935a93b5fb251688d…

### DIFF
--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/leatherman.git","ref":"5a63a79f8358647935a93b5fb251688df5a8bf9c"}
+{"url":"git://github.com/puppetlabs/leatherman.git","ref":"20a7fb2e3497a370a3e013b81dd56e1405f57da2"}


### PR DESCRIPTION
…f5a8bf9c"

This reverts commit f73005490f61d2ead8a99a276d82c4ba1f15cf16.

Revert leatherman to the latest tagged SHA to avoid having to release,
since the updates in 5a63a79f8358647935a93b5fb251688df5a8bf9c
specifically target the README file and are not user-facing.