### PR TITLE
(maint) PA-4182 replace git:// with https://

### DIFF
--- a/configs/components/cpp-hocon.json
+++ b/configs/components/cpp-hocon.json
@@ -1,1 +1,1 @@
-{"url": "git://github.com/puppetlabs/cpp-hocon.git", "ref": "f6ba8d4ae898ae8e0e9c2e3f96a27e5fd566752d"}
+{"url": "https://github.com/puppetlabs/cpp-hocon.git", "ref": "f6ba8d4ae898ae8e0e9c2e3f96a27e5fd566752d"}

--- a/configs/components/cpp-pcp-client.json
+++ b/configs/components/cpp-pcp-client.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/cpp-pcp-client.git","ref":"db234c7d2ec20eb2370bb5c00d249e10ddc12365"}
+{"url":"https://github.com/puppetlabs/cpp-pcp-client.git","ref":"db234c7d2ec20eb2370bb5c00d249e10ddc12365"}

--- a/configs/components/leatherman.json
+++ b/configs/components/leatherman.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/leatherman.git","ref":"0fa97de5432eaf14883775d69423be1b3cc37c1d"}
+{"url":"https://github.com/puppetlabs/leatherman.git","ref":"0fa97de5432eaf14883775d69423be1b3cc37c1d"}

--- a/configs/components/nssm.json
+++ b/configs/components/nssm.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/nssm.git","ref":"refs/tags/2.25.0"}
+{"url":"https://github.com/puppetlabs/nssm.git","ref":"refs/tags/2.25.0"}

--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1,1 +1,1 @@
-{"url":"git://github.com/puppetlabs/pxp-agent.git","ref":"ca94594aa5c58a559761ca8387d88f6458f62cb5"}
+{"url":"https://github.com/puppetlabs/pxp-agent.git","ref":"ca94594aa5c58a559761ca8387d88f6458f62cb5"}


### PR DESCRIPTION
Replacing Git protocol since it will no longer be supported.