### PR TITLE
(PA-4319) Snyk monitor pushes to main

### DIFF
--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -1,0 +1,27 @@
+---
+name: Snyk Monitor
+on:
+  push:
+    branches:
+      - main
+jobs:
+  snyk_monitor:
+    if: ${{ github.repository_owner == 'puppetlabs' }}
+    runs-on: ubuntu-latest
+    name: Snyk Monitor
+    steps:
+      - name: Checkout current PR
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Install dependencies
+        run: bundle install --jobs 3 --retry 3
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/ruby@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_PE_TOKEN }}
+        with:
+          command: monitor
+          args: --org=puppet-enterprise --project-name=${{ github.repository }}


### PR DESCRIPTION
This monitors the ruby gems that vanagon uses to build the C++ pxp-agent components. The generated artifact doesn't contain any gems.

See https://github.com/puppetlabs/pxp-agent-vanagon/runs/5515470085