### PR TITLE
(maint) Adds workaround for EL8 PPCLE subscription

### DIFF
--- a/configs/platforms/el-8-ppc64le.rb
+++ b/configs/platforms/el-8-ppc64le.rb
@@ -3,6 +3,9 @@ platform 'el-8-ppc64le' do |plat|
   plat.defaultdir '/etc/sysconfig'
   plat.servicetype 'systemd'
 
+  # Workaround for an issue with RedHat subscription metadata, see ITSYS-2543
+  plat.provision_with('subscription-manager repos --disable rhel-8-for-ppc64le-baseos-rpms && subscription-manager repos --enable rhel-8-for-ppc64le-baseos-rpms')
+
   packages = %w[make cmake gcc-c++ libarchive]
   plat.provision_with("dnf install -y --allowerasing  #{packages.join(' ')}")
   plat.install_build_dependencies_with 'dnf install -y --allowerasing'


### PR DESCRIPTION
We are consistently encountering an issue with RedHat Enterprise
Linux 8 on little-endian PowerPC where yum/dnf cannot fetch
repository metadata due to a perceived subscription issue.

This commit disables then reenables that repository, which seems
to work around the issue.

See https://access.redhat.com/discussions/4656371#comment-1769061

Thank you @joshcooper for finding this fix.