### PR TITLE
(PA-4515) Removes Ubuntu 16.04

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -33,7 +33,7 @@ component 'cpp-hocon' do |pkg, settings, platform|
 
     cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-(:?16.04|18.04-amd64)/ ||
+  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/ ||
         platform.is_aix?
     toolchain = '-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake'
     cmake = '/opt/pl-build-tools/bin/cmake'

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -45,7 +45,7 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
 
     cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-(:?16.04|18.04-amd64)/
+  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
     # use default that is pl-build-tools
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -16,7 +16,7 @@ component 'leatherman' do |pkg, settings, platform|
   elsif platform.is_windows?
     pkg.build_requires 'cmake'
     pkg.build_requires "pl-gettext-#{platform.architecture}"
-  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-(:?16.04|18.04-amd64)/
+  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
     pkg.build_requires 'pl-cmake'
     pkg.build_requires 'pl-gettext'
     pkg.build_requires 'runtime'
@@ -71,7 +71,7 @@ component 'leatherman' do |pkg, settings, platform|
 
     # Use environment variable set in environment.bat to find locale files
     leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"
-  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-(:?16.04|18.04-amd64)/ ||
+  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/ ||
         platform.is_aix?
     toolchain = '-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake'
     cmake = '/opt/pl-build-tools/bin/cmake'

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -56,7 +56,7 @@ component 'pxp-agent' do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
     special_flags += ' -DDYNAMICBASE=OFF' if platform.name =~ /windowsfips-2012r2/
 
-  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-(:?16.04|18.04-amd64)/
+  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
     # use default that is pl-build-tools
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools

--- a/configs/components/runtime.rb
+++ b/configs/components/runtime.rb
@@ -10,7 +10,7 @@ component 'runtime' do |pkg, _settings, platform|
     pkg.build_requires "pl-iconv-#{platform.architecture}"
     pkg.build_requires "pl-libffi-#{platform.architecture}"
     pkg.build_requires "pl-pdcurses-#{platform.architecture}"
-  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-(:?16.04|18.04-amd64)/
+  elsif platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
     pkg.build_requires 'pl-gcc'
   end
 end

--- a/configs/platforms/ubuntu-16.04-amd64.rb
+++ b/configs/platforms/ubuntu-16.04-amd64.rb
@@ -1,3 +1,0 @@
-platform "ubuntu-16.04-amd64" do |plat|
-  plat.inherit_from_default
-end

--- a/configs/platforms/ubuntu-16.04-i386.rb
+++ b/configs/platforms/ubuntu-16.04-i386.rb
@@ -1,3 +1,0 @@
-platform "ubuntu-16.04-i386" do |plat|
-  plat.inherit_from_default
-end

--- a/configs/projects/pxp-agent.rb
+++ b/configs/projects/pxp-agent.rb
@@ -29,7 +29,7 @@ project 'pxp-agent' do |proj|
   proj.setting(:service_conf, File.join(proj.install_root, 'service_conf'))
 
   proj.component 'puppet-runtime'
-  proj.component 'runtime' if platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-(:?16.04|18.04-amd64)/ || !platform.is_linux?
+  proj.component 'runtime' if platform.name =~ /debian-9|el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/ || !platform.is_linux?
 
   proj.component 'leatherman'
   proj.component 'cpp-hocon'


### PR DESCRIPTION
Ubuntu 16.04 hit end-of-life in April 2021. This commit removes Ubuntu 16.04 from all Vanagon platforms, components, and projects.