### PR TITLE
(PA-4663) Updates Ubuntu GitHub Action runners

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {check: rubocop, os: ubuntu-18.04, ruby: 2.5}
-          - {check: commits, os: ubuntu-18.04, ruby: 2.5}
+          - {check: rubocop, os: ubuntu-latest, ruby: 2.5}
+          - {check: commits, os: ubuntu-latest, ruby: 2.5}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:


### PR DESCRIPTION
GitHub is deprecating Ubuntu 18.04 runners on April 1, 2023. This commit switches all Ubuntu 18.04 used in GitHub Actions to ubuntu-latest (currently Ubuntu 20.04).