### PR TITLE
(maint) Fix solaris-11-sparc libraries

### DIFF
--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -52,7 +52,8 @@ component 'leatherman' do |pkg, settings, platform|
   elsif platform.is_solaris?
     if platform.architecture == 'sparc'
       ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"
-      special_flags += " -DCMAKE_EXE_LINKER_FLAGS=' /opt/puppetlabs/puppet/lib/libssl.so /opt/puppetlabs/puppet/lib/libcrypto.so /opt/puppetlabs/puppet/lib/libgcc_s.so' "
+      special_flags += " -DCMAKE_EXE_LINKER_FLAGS=' /opt/puppetlabs/puppet/lib/libssl.so /opt/puppetlabs/puppet/lib/libcrypto.so /opt/puppetlabs/puppet/lib/libgcc_s.so' " if platform.name =~ /^solaris-10/
+      special_flags += " -DCMAKE_EXE_LINKER_FLAGS=' /opt/puppetlabs/puppet/lib/libssl.so /opt/puppetlabs/puppet/lib/libcrypto.so' " if platform.name =~ /^solaris-11/
     end
 
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -47,7 +47,8 @@ component 'pxp-agent' do |pkg, settings, platform|
     # PCP-87: If we build with -O3, solaris segfaults due to something in std::vector
     special_flags += " -DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG' "
 
-    special_flags += " -DCMAKE_EXE_LINKER_FLAGS=' /opt/puppetlabs/puppet/lib/libssl.so /opt/puppetlabs/puppet/lib/libgcc_s.so /opt/puppetlabs/puppet/lib/libcrypto.so' " if platform.architecture == 'sparc'
+    special_flags += " -DCMAKE_EXE_LINKER_FLAGS=' /opt/puppetlabs/puppet/lib/libssl.so /opt/puppetlabs/puppet/lib/libgcc_s.so /opt/puppetlabs/puppet/lib/libcrypto.so' " if platform.name =~ /^solaris-10/
+    special_flags += " -DCMAKE_EXE_LINKER_FLAGS=' /opt/puppetlabs/puppet/lib/libssl.so /opt/puppetlabs/puppet/lib/libcrypto.so' " if platform.name =~ /^solaris-11/
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
     pkg.environment 'CYGWIN', settings[:cygwin]


### PR DESCRIPTION
Solaris-11-sparc somehow has `libgcc_s.so` already in its path. With the recent fix for solaris-10-sparc we are now declaring `libgcc_s.so` twice, and that produces an error at compliation time.
This PR simply doesn't apply that library for solaris-11-sparc.