### PR TITLE
(maint) Solaris-10 non sparc fix

### DIFF
--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -47,8 +47,12 @@ component 'pxp-agent' do |pkg, settings, platform|
     # PCP-87: If we build with -O3, solaris segfaults due to something in std::vector
     special_flags += " -DCMAKE_CXX_FLAGS_RELEASE='-O2 -DNDEBUG' "
 
-    special_flags += " -DCMAKE_EXE_LINKER_FLAGS=' /opt/puppetlabs/puppet/lib/libssl.so /opt/puppetlabs/puppet/lib/libgcc_s.so /opt/puppetlabs/puppet/lib/libcrypto.so' " if platform.name =~ /^solaris-10/
-    special_flags += " -DCMAKE_EXE_LINKER_FLAGS=' /opt/puppetlabs/puppet/lib/libssl.so /opt/puppetlabs/puppet/lib/libcrypto.so' " if platform.name =~ /^solaris-11/
+    special_flags += if platform.name =~ /^solaris-10-sparc/
+                       " -DCMAKE_EXE_LINKER_FLAGS=' /opt/puppetlabs/puppet/lib/libssl.so /opt/puppetlabs/puppet/lib/libgcc_s.so /opt/puppetlabs/puppet/lib/libcrypto.so' "
+                     else
+                       " -DCMAKE_EXE_LINKER_FLAGS=' /opt/puppetlabs/puppet/lib/libssl.so /opt/puppetlabs/puppet/lib/libcrypto.so' "
+                     end
+
   elsif platform.is_windows?
     make = "#{settings[:gcc_bindir]}/mingw32-make"
     pkg.environment 'CYGWIN', settings[:cygwin]


### PR DESCRIPTION
Solaris-10-x86_64, and both versions of solaris-11 already have `libgcc_s.so` in the path. So we only want to add that for solaris-10-sparc. 