### PR TITLE
(maint) Remove output directory command

### DIFF
--- a/configs/platforms/osx-11-x86_64.rb
+++ b/configs/platforms/osx-11-x86_64.rb
@@ -17,5 +17,4 @@ platform 'osx-11-x86_64' do |plat|
   plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/'
   plat.vmpooler_template 'macos-112-x86_64'
-  plat.output_dir File.join('apple', '11', 'puppet7', 'x86_64')
 end

--- a/configs/platforms/osx-12-arm64.rb
+++ b/configs/platforms/osx-12-arm64.rb
@@ -18,5 +18,4 @@ platform 'osx-12-arm64' do |plat|
   plat.provision_with 'sudo chown -R test:admin /Users/test/'
   plat.vmpooler_template 'macos-12-x86_64'
   plat.cross_compiled true
-  plat.output_dir File.join('apple', '12', 'puppet7', 'arm64')
 end

--- a/configs/platforms/osx-12-x86_64.rb
+++ b/configs/platforms/osx-12-x86_64.rb
@@ -17,5 +17,4 @@ platform 'osx-12-x86_64' do |plat|
   plat.provision_with 'su test -c \'echo | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"\''
   plat.provision_with 'sudo chown -R test:admin /Users/test/'
   plat.vmpooler_template 'macos-12-x86_64'
-  plat.output_dir File.join('apple', '12', 'puppet7', 'x86_64')
 end


### PR DESCRIPTION
This commit removes the plat.output_dir command from  macOS 11 (x86) and 12 (x86 & arm) platform definitions since pxp-agent-vanagon does not have that file structure, everything is stored under the artifacts directory on builds.delivery.puppetlabs.net
