### PR TITLE
(maint) Updates Ruby version in GitHub Actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {check: rubocop, os: ubuntu-latest, ruby: 2.5}
-          - {check: commits, os: ubuntu-latest, ruby: 2.5}
+          - {check: rubocop, os: ubuntu-latest, ruby: 2.7}
+          - {check: commits, os: ubuntu-latest, ruby: 2.7}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:


### PR DESCRIPTION
This commit updates the Ruby version used in our GitHub Actions checks from Ruby 2.5 (which is end-of-life) to Ruby 2.7.