### PR TITLE
(PA-4870) Patch cmake for OpenSSL 3

### DIFF
--- a/configs/components/pl-cmake-patch.rb
+++ b/configs/components/pl-cmake-patch.rb
@@ -1,0 +1,25 @@
+# OpenSSL 3 introduced a new versioning scheme. CMake < 3.18 doesn't
+# understand the new scheme and will fail to `FindOpenSSL`. So patch
+# cmake on platforms that need it. However, I wasn't able to just
+# use the latest version of FindOpenSSL.cmake, so apply cherry-picked
+# commits
+component 'pl-cmake-patch' do |pkg, settings, platform|
+  if platform.is_windows?
+    pkg.add_source 'file://patches/cmake/0001-FindOpenSSL-Tolerate-tabs-in-header-while-parsing-ve.patch'
+    pkg.add_source 'file://patches/cmake/0002-FindOpenSSL-Do-not-assume-that-the-version-regex-fin.patch'
+    pkg.add_source 'file://patches/cmake/0003-FindOpenSSL-Detect-OpenSSL-3.0.0.patch'
+    pkg.add_source 'file://patches/cmake/0004-FindOpenSSL-Fix-OpenSSL-3.0.0-version-extraction.patch'
+
+    modules = "#{settings[:chocolatey_lib]}/cmake/content/cmake-3.2.2-win32-x86/share/cmake-3.2"
+    patch_options = '--strip=1 --fuzz=0 --ignore-whitespace --no-backup-if-mismatch'
+    unix2dos = 'awk -v ORS="\r\n" 1'
+    pkg.configure do
+      [
+        %(#{unix2dos} 0001-FindOpenSSL-Tolerate-tabs-in-header-while-parsing-ve.patch | #{platform[:patch]} #{patch_options} --dir $(shell cygpath -u #{modules})),
+        %(#{unix2dos} 0002-FindOpenSSL-Do-not-assume-that-the-version-regex-fin.patch | #{platform[:patch]} #{patch_options} --dir $(shell cygpath -u #{modules})),
+        %(#{unix2dos} 0003-FindOpenSSL-Detect-OpenSSL-3.0.0.patch                     | #{platform[:patch]} #{patch_options} --dir $(shell cygpath -u #{modules})),
+        %(#{unix2dos} 0004-FindOpenSSL-Fix-OpenSSL-3.0.0-version-extraction.patch     | #{platform[:patch]} #{patch_options} --dir $(shell cygpath -u #{modules}))
+      ]
+    end
+  end
+end

--- a/configs/projects/pxp-agent.rb
+++ b/configs/projects/pxp-agent.rb
@@ -27,7 +27,9 @@ project 'pxp-agent' do |proj|
   proj.inherit_yaml_settings(settings_uri, sha1sum_uri, metadata_uri: metadata_uri)
 
   proj.setting(:service_conf, File.join(proj.install_root, 'service_conf'))
+  proj.setting(:chocolatey_lib, 'C:/ProgramData/chocolatey/lib') if platform.is_windows?
 
+  proj.component 'pl-cmake-patch'
   proj.component 'puppet-runtime'
   proj.component 'runtime' if platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/ || !platform.is_linux?
 

--- a/patches/cmake/0001-FindOpenSSL-Tolerate-tabs-in-header-while-parsing-ve.patch
+++ b/patches/cmake/0001-FindOpenSSL-Tolerate-tabs-in-header-while-parsing-ve.patch
@@ -1,0 +1,29 @@
+From 6962c466e5a02c4b8a7b7db7645e2403c01bb76c Mon Sep 17 00:00:00 2001
+From: Wayne Stambaugh <stambaughw@gmail.com>
+Date: Sat, 3 Oct 2015 11:40:00 -0400
+Subject: [PATCH 1/4] FindOpenSSL: Tolerate tabs in header while parsing
+ version (#15765)
+
+Tolerate tabs instead of spaces in the "# define" line.
+
+(cherry picked from commit 6b575dec8d393c4a38c587ee97afa068eeb4b432)
+---
+ Modules/FindOpenSSL.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Modules/FindOpenSSL.cmake b/Modules/FindOpenSSL.cmake
+index 3adc269262..b97db51866 100644
+--- a/Modules/FindOpenSSL.cmake
++++ b/Modules/FindOpenSSL.cmake
+@@ -285,7 +285,7 @@ endfunction()
+ if (OPENSSL_INCLUDE_DIR)
+   if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+     file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
+-         REGEX "^# *define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
++         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
+ 
+     # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
+     # The status gives if this is a developer or prerelease and is ignored here.
+-- 
+2.25.1
+

--- a/patches/cmake/0002-FindOpenSSL-Do-not-assume-that-the-version-regex-fin.patch
+++ b/patches/cmake/0002-FindOpenSSL-Do-not-assume-that-the-version-regex-fin.patch
@@ -1,0 +1,36 @@
+From 962b338e9dae4a41c05fb0804d077e6ee2396346 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Vladim=C3=ADr=20Vondru=C5=A1?= <mosra@centrum.cz>
+Date: Thu, 9 Jun 2016 14:03:47 +0200
+Subject: [PATCH 2/4] FindOpenSSL: Do not assume that the version regex finds
+ something
+
+BoringSSL's openslv.h does not have the version information.
+
+(cherry picked from commit e937b4c3879e1ee0770b465c0cdcbb6a960ba892)
+---
+ Modules/FindOpenSSL.cmake | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Modules/FindOpenSSL.cmake b/Modules/FindOpenSSL.cmake
+index b97db51866..3fc398bd9f 100644
+--- a/Modules/FindOpenSSL.cmake
++++ b/Modules/FindOpenSSL.cmake
+@@ -282,11 +282,11 @@ function(from_hex HEX DEC)
+   set(${DEC} ${_res} PARENT_SCOPE)
+ endfunction()
+ 
+-if (OPENSSL_INCLUDE_DIR)
+-  if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+-    file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
+-         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
++if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
++  file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
++       REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x([0-9a-fA-F])+.*")
+ 
++  if(openssl_version_str)
+     # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
+     # The status gives if this is a developer or prerelease and is ignored here.
+     # Major, minor, and fix directly translate into the version numbers shown in
+-- 
+2.25.1
+

--- a/patches/cmake/0003-FindOpenSSL-Detect-OpenSSL-3.0.0.patch
+++ b/patches/cmake/0003-FindOpenSSL-Detect-OpenSSL-3.0.0.patch
@@ -1,0 +1,42 @@
+From fd17a0add77dac9ffda5307604c6f6b87ddf2875 Mon Sep 17 00:00:00 2001
+From: Vitezslav Cizek <vcizek@suse.com>
+Date: Wed, 27 May 2020 14:52:17 +0200
+Subject: [PATCH 3/4] FindOpenSSL: Detect OpenSSL 3.0.0
+
+The OpenSSL versioning is changing with the upcoming 3.0.0 release.
+https://www.openssl.org/blog/blog/2018/11/28/version/
+Since 3.0.0, the patch letters are being dropped. The new format is:
+MAJOR.MINOR.PATCH
+
+The OPENSSL_VERSION variable can now be directly derived from the new
+OPENSSL_VERSION_STR macro.
+https://www.openssl.org/docs/manmaster/man3/OPENSSL_VERSION_NUMBER.html
+
+(cherry picked from commit 61d746e5922de50310558364f157b261f3e7917a)
+---
+ Modules/FindOpenSSL.cmake | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/Modules/FindOpenSSL.cmake b/Modules/FindOpenSSL.cmake
+index 3fc398bd9f..1432d2f4c5 100644
+--- a/Modules/FindOpenSSL.cmake
++++ b/Modules/FindOpenSSL.cmake
+@@ -315,6 +315,15 @@ if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+     endif ()
+ 
+     set(OPENSSL_VERSION "${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}.${OPENSSL_VERSION_FIX}${OPENSSL_VERSION_PATCH_STRING}")
++  else ()
++    # Since OpenSSL 3.0.0, the new version format is MAJOR.MINOR.PATCH and
++    # a new OPENSSL_VERSION_STR macro contains exactly that
++    file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" OPENSSL_VERSION_STR
++         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_STR[\t ]+\"([0-9])+\.([0-9])+\.([0-9])+\".*")
++    string(REGEX REPLACE "^.*OPENSSL_VERSION_STR[\t ]+\"([0-9]+\.[0-9]+\.[0-9]+)\".*$"
++           "\\1" OPENSSL_VERSION_STR "${OPENSSL_VERSION_STR}")
++
++    set(OPENSSL_VERSION "${OPENSSL_VERSION_STR}")
+   endif ()
+ endif ()
+ 
+-- 
+2.25.1
+

--- a/patches/cmake/0004-FindOpenSSL-Fix-OpenSSL-3.0.0-version-extraction.patch
+++ b/patches/cmake/0004-FindOpenSSL-Fix-OpenSSL-3.0.0-version-extraction.patch
@@ -1,0 +1,39 @@
+From 433ec42c8af1e519000521a7dfab9bbdf7b2c701 Mon Sep 17 00:00:00 2001
+From: Billy Brumley <bbrumley@gmail.com>
+Date: Sat, 6 Jun 2020 10:31:59 +0300
+Subject: [PATCH 4/4] FindOpenSSL: Fix OpenSSL 3.0.0 version extraction
+
+Fix the regex syntax added by commit 61d746e592 (FindOpenSSL: Detect
+OpenSSL 3.0.0, 2020-05-27, v3.17.3~1^2).  Add missing escapes.
+Test with `openssl-3.0.0-alpha3`.
+
+While at it, also unset a temporary variable after use.
+
+(cherry picked from commit 796b447373ea8b085a8e41903dacdf9cc27f171a)
+---
+ Modules/FindOpenSSL.cmake | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/Modules/FindOpenSSL.cmake b/Modules/FindOpenSSL.cmake
+index 1432d2f4c5..fd5a051490 100644
+--- a/Modules/FindOpenSSL.cmake
++++ b/Modules/FindOpenSSL.cmake
+@@ -319,11 +319,13 @@ if(OPENSSL_INCLUDE_DIR AND EXISTS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h")
+     # Since OpenSSL 3.0.0, the new version format is MAJOR.MINOR.PATCH and
+     # a new OPENSSL_VERSION_STR macro contains exactly that
+     file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" OPENSSL_VERSION_STR
+-         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_STR[\t ]+\"([0-9])+\.([0-9])+\.([0-9])+\".*")
+-    string(REGEX REPLACE "^.*OPENSSL_VERSION_STR[\t ]+\"([0-9]+\.[0-9]+\.[0-9]+)\".*$"
++         REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_STR[\t ]+\"([0-9])+\\.([0-9])+\\.([0-9])+\".*")
++    string(REGEX REPLACE "^.*OPENSSL_VERSION_STR[\t ]+\"([0-9]+\\.[0-9]+\\.[0-9]+)\".*$"
+            "\\1" OPENSSL_VERSION_STR "${OPENSSL_VERSION_STR}")
+ 
+     set(OPENSSL_VERSION "${OPENSSL_VERSION_STR}")
++
++    unset(OPENSSL_VERSION_STR)
+   endif ()
+ endif ()
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
OpenSSL 3 introduced a new versioning scheme. CMake < 3.18 doesn't
understand the new scheme and will fail to `FindOpenSSL`.

Additionally, the version of CMake installed via chocolatey on Windows contains
\r\n line endings, so perform unix2dos on Windows when patching. We use awk
because it's already installed, while dos2unix is not.

Built [pxp-agent-vanagon#5487502e7](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/1972/) using `agent-runtime-main#202303080`

Running [`puppet-agent#30bd0c8340428814ab9d6f930cfe2cc954d3b80c` adhoc](https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-packaging_adhoc-ad_hoc/1273/) with
```diff
diff --git a/configs/components/puppet-runtime.json b/configs/components/puppet-runtime.json
index 21f7ef8d2..0435f24b1 100644
--- a/configs/components/puppet-runtime.json
+++ b/configs/components/puppet-runtime.json
@@ -1 +1 @@
-{"location":"https://builds.delivery.puppetlabs.net/puppet-runtime/202303100/artifacts/","version":"202303100"}
+{"location":"https://builds.delivery.puppetlabs.net/puppet-runtime/202303080/artifacts/","version":"202303080"}
diff --git a/configs/components/pxp-agent.json b/configs/components/pxp-agent.json
index a868a794c..a3dc69fc6 100644
--- a/configs/components/pxp-agent.json
+++ b/configs/components/pxp-agent.json
@@ -1 +1 @@
-{"location":"https://builds.delivery.puppetlabs.net/pxp-agent/202303110/artifacts/","version":"202303110"}
+{"location":"https://builds.delivery.puppetlabs.net/pxp-agent/5487502e713f867b3ba0eafb54bc876417d6b078/artifacts/","version":"202302081.12.g5487502"}
```

I think ideally these changes would go into `pl-build-tools-vanagon`, however, `pl-cmake` doesn't build on Windows. So sticking with this for now. For non-Windows platforms, I submitted a similar PR to https://github.com/puppetlabs/pl-build-tools-vanagon/pull/92