### PR TITLE
(PA-5427) Enable dynamicbase on Windows FIPS

### DIFF
--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -68,7 +68,7 @@ component 'leatherman' do |pkg, settings, platform|
 
     cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-    special_flags += " -DDYNAMICBASE=OFF -DCMAKE_CXX_FLAGS='-Wno-deprecated-declarations' " if platform.name =~ /windowsfips-2012r2/
+    special_flags += " -DCMAKE_CXX_FLAGS='-Wno-deprecated-declarations' "
 
     # Use environment variable set in environment.bat to find locale files
     leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -59,7 +59,6 @@ component 'pxp-agent' do |pkg, settings, platform|
 
     cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-    special_flags += ' -DDYNAMICBASE=OFF' if platform.name =~ /windowsfips-2012r2/
 
   elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
     # use default that is pl-build-tools


### PR DESCRIPTION
It's no longer necessary to disable dynamicbase with OpenSSL 3 on Windows FIPS.

Blocked on https://github.com/puppetlabs/puppet-runtime/pull/670