### PR TITLE
(PA-5028) Remove macOS 10.15 (x86_64) from the pxp-agent-vanagon repo…

### DIFF
--- a/configs/platforms/osx-10.15-x86_64.rb
+++ b/configs/platforms/osx-10.15-x86_64.rb
@@ -1,3 +1,0 @@
-platform "osx-10.15-x86_64" do |plat|
-  plat.inherit_from_default
-end


### PR DESCRIPTION
…sitory