### PR TITLE
(PA-5593) Pin to chocolatey 1.4.0

### DIFF
--- a/configs/platforms/windows-2012r2-x64.rb
+++ b/configs/platforms/windows-2012r2-x64.rb
@@ -6,14 +6,13 @@ platform 'windows-2012r2-x64' do |plat|
   visual_studio_sdk_version = 'win8.1'
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
-  plat.add_build_repository 'https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey.ps1'
+  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey-1.4.0.ps1"
   plat.add_build_repository 'https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/nuget'
 
   # C:\tools is likely added by mingw, however because we also want to use that
   # dir for vsdevcmd.bat we create it for safety
   plat.provision_with 'mkdir C:/tools'
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey --no-progress'
   plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey'
 
   plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress'

--- a/configs/platforms/windows-2012r2-x86.rb
+++ b/configs/platforms/windows-2012r2-x86.rb
@@ -7,14 +7,13 @@ platform 'windows-2012r2-x86' do |plat|
   visual_studio_sdk_version = 'win8.1'
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
-  plat.add_build_repository 'https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey.ps1'
+  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey-1.4.0.ps1"
   plat.add_build_repository 'https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/nuget'
 
   # C:\tools is likely added by mingw, however because we also want to use that
   # dir for vsdevcmd.bat we create it for safety
   plat.provision_with 'mkdir C:/tools'
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey --no-progress'
   plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey'
 
   plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w32 -version 5.2.0 -debug -x86 --no-progress'

--- a/configs/platforms/windowsfips-2012r2-x64.rb
+++ b/configs/platforms/windowsfips-2012r2-x64.rb
@@ -6,7 +6,7 @@ platform 'windowsfips-2012r2-x64' do |plat|
   visual_studio_sdk_version = 'win8.1'
 
   # We need to ensure we install chocolatey prior to adding any nuget repos. Otherwise, everything will fall over
-  plat.add_build_repository 'https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey.ps1'
+  plat.add_build_repository "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/chocolatey/install-chocolatey-1.4.0.ps1"
   plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe feature enable -n useFipsCompliantChecksums'
 
   plat.add_build_repository 'https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/nuget'
@@ -15,7 +15,6 @@ platform 'windowsfips-2012r2-x64' do |plat|
   # dir for vsdevcmd.bat we create it for safety
   plat.provision_with 'mkdir -p C:/tools'
   # We don't want to install any packages from the chocolatey repo by accident
-  plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe upgrade -y chocolatey --no-progress'
   plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe sources remove -name chocolatey'
 
   plat.provision_with 'C:/ProgramData/chocolatey/bin/choco.exe install -y mingw-w64 -version 5.2.0 -debug --no-progress'


### PR DESCRIPTION
Chocolatey 2.0 dropped the deprecated Get-BinRoot script which mingw-w64 relies on, so pin back to 1.4.0 for now. We also have to disable upgrades so we don't upgrade to 2.0.

I cherry-picked this commit and manually built windows-2012r2-x64.