### PR TITLE
(PA-4776) Add macOS 13 (ARM) platform definition to pxp-agent-vanagon…

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -17,6 +17,11 @@ component 'cpp-hocon' do |pkg, settings, platform|
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
     end
+
+    if platform.architecture == 'arm64' && platform.os_version.to_i >= 13
+      pkg.environment 'CXX', 'clang++'
+      cmake = '/opt/homebrew/bin/cmake'
+    end
   elsif platform.is_cross_compiled_linux?
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"
     cmake = '/opt/pl-build-tools/bin/cmake'

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -33,6 +33,11 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
     end
+
+    if platform.os_version.to_i >= 13 && platform.architecture == 'arm64'
+      cmake = '/opt/homebrew/bin/cmake'
+      pkg.environment 'CXX', 'clang++'
+    end
   elsif platform.is_cross_compiled_linux?
     cmake = '/opt/pl-build-tools/bin/cmake'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -43,6 +43,11 @@ component 'leatherman' do |pkg, settings, platform|
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
     end
+
+    if platform.os_version.to_i >= 13 && platform.architecture == 'arm64'
+      cmake = '/opt/homebrew/bin/cmake'
+      pkg.environment 'CXX', 'clang++'
+    end
   elsif platform.is_cross_compiled_linux?
     ruby = "#{settings[:host_ruby]} -r#{settings[:datadir]}/doc/rbconfig-#{settings[:ruby_version]}-orig.rb"
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -37,6 +37,11 @@ component 'pxp-agent' do |pkg, settings, platform|
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos11' if platform.name =~ /osx-11/
       pkg.environment 'CXX', 'clang++ -target arm64-apple-macos12' if platform.name =~ /osx-12/
     end
+
+    if platform.os_version.to_i >= 13 && platform.architecture == 'arm64'
+      cmake = '/opt/homebrew/bin/cmake'
+      pkg.environment 'CXX', 'clang++'
+    end
   elsif platform.is_cross_compiled_linux?
     cmake = '/opt/pl-build-tools/bin/cmake'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/#{settings[:platform_triple]}/pl-build-toolchain.cmake"

--- a/configs/platforms/osx-13-arm64.rb
+++ b/configs/platforms/osx-13-arm64.rb
@@ -1,0 +1,4 @@
+platform 'osx-13-arm64' do |plat|
+  plat.inherit_from_default
+  plat.output_dir File.join('apple', '13', 'puppet7', 'arm64')
+end


### PR DESCRIPTION
… for 7.x

[Artifacts link](http://builds.delivery.puppetlabs.net/pxp-agent/041643de5384395858a3d453d5b79e1dd10dfa69/artifacts/?C=M&O=D)

[Vanagon generic pipeline](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-generic-builder-init_generic-builder/)