### PR TITLE
(PA-5644) Use yum update on AIX

### DIFF
--- a/configs/platforms/aix-7.2-ppc.rb
+++ b/configs/platforms/aix-7.2-ppc.rb
@@ -18,6 +18,11 @@ curl --output yum.sh https://artifactory.delivery.puppetlabs.net/artifactory/gen
 rpm -Uvh https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS/ppc/sed/sed-4.1.1-1.aix5.1.ppc.rpm;
 /opt/freeware/bin/sed -i 's|https://anonymous:anonymous@public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS|https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_aix_linux_toolbox/RPMS|' /opt/freeware/etc/yum/yum.conf)
 
+  # Since we updated openssl.base, run updtvpkg so that RPM packages that we install
+  # later build against the new openssl.
+  # See https://www.ibm.com/support/pages/understanding-aix-virtual-rpm-package-rpmrte
+  plat.provision_with 'updtvpkg'
+
   # yum.sh downloads rpm.rte containing several base packages including curl
   # 7.51. However, that version isn't compatible with cmake. If we update curl
   # specifically, then yum/python/libcurl will be in an inconsistent state. So


### PR DESCRIPTION
Whenver a fileset is installed via installp, e.g. openssl.base, IBM recommends running updtvpkg so that RPM packages which depend on it, build correctly.

See also puppetlabs/puppet-runtime@a46d6e1d33ca748de66f76c915df625cb1e1ded2

Built https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2138/BUILD_TARGET=aix-7.2-ppc,SLAVE_LABEL=k8s-worker/