### PR TITLE
(PA-5001) Add Red Hat 9 (ARM64) platform definition to pxp-agent-vana…

### DIFF
--- a/configs/platforms/el-9-aarch64.rb
+++ b/configs/platforms/el-9-aarch64.rb
@@ -1,0 +1,3 @@
+platform "el-9-aarch64" do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
…gon#7.x

pxp-agent build for 7.x: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=el-9-aarch64,SLAVE_LABEL=k8s-worker/2339/

Linked CJC PR: https://github.com/puppetlabs/ci-job-configs/pull/9144