### PR TITLE
(PA-4608) Add debian-11-aarch64 platform definition file

### DIFF
--- a/configs/platforms/debian-11-aarch64.rb
+++ b/configs/platforms/debian-11-aarch64.rb
@@ -1,0 +1,3 @@
+platform "debian-11-aarch64" do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
The pxp-agent build for debian-11-arm64 7.x stream is available here: https://builds.delivery.puppetlabs.net/pxp-agent/6880a86739aef76056c74057b4e089a0acfd8c9d/artifacts/?C=M&O=D

The jenkins job to build it was this: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2392/
