### PR TITLE
(PA-5742) Add the debian-11 (ARM64) definition file to main stream

### DIFF
--- a/configs/platforms/debian-11-aarch64.rb
+++ b/configs/platforms/debian-11-aarch64.rb
@@ -1,0 +1,3 @@
+platform "debian-11-aarch64" do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
The pxp-agent build for debian-11-arm64 main stream is available here: https://builds.delivery.puppetlabs.net/pxp-agent/2dc1f4d072c110a8fdc13270216e4a5be79b52c9/artifacts/?C=M&O=D

The jenkins job to build it was this: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2393/