### PR TITLE
(PA-5569) Amazon Linux 2023 platform definition to pxp-agent-vanagon

### DIFF
--- a/configs/platforms/amazon-2023-aarch64.rb
+++ b/configs/platforms/amazon-2023-aarch64.rb
@@ -1,0 +1,3 @@
+platform "amazon-2023-aarch64" do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/amazon-2023-x86_64.rb
+++ b/configs/platforms/amazon-2023-x86_64.rb
@@ -1,0 +1,3 @@
+platform "amazon-2023-aarch64" do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
### amazon-2023-aarch64
* Build: [platform_vanagon-generic-builder_vanagon-packaging_generic-builder](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=amazon-2023-aarch64,SLAVE_LABEL=k8s-worker/2479/console
)
* Artifact: [amazon-2023-aarch64.tar.gz](http://builds.delivery.puppetlabs.net/pxp-agent/6a94c5f0932c4533ae63581457b48ebcd40a822a/artifacts/pxp-agent-202308310.27.g6a94c5f.amazon-2023-aarch64.tar.gz)

### amazon-2023-x86_64
* Build: [platform_vanagon-generic-builder_vanagon-packaging_generic-builder](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=amazon-2023-x86_64,SLAVE_LABEL=k8s-worker/2480/console
)
* Artifact: [amazon-2023-x86_64.tar.gz](http://builds.delivery.puppetlabs.net/pxp-agent/6a94c5f0932c4533ae63581457b48ebcd40a822a/artifacts/pxp-agent-202308310.27.g6a94c5f.amazon-2023-x86_64.tar.gz
)