### PR TITLE
(PA-5879) Add macOS 14 (Intel) platform definition to pxp-agent-vanagon-main

### DIFF
--- a/configs/platforms/osx-14-x86_64.rb
+++ b/configs/platforms/osx-14-x86_64.rb
@@ -1,0 +1,3 @@
+platform 'osx-14-x86_64' do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
Artifact:
https://builds.delivery.puppetlabs.net/pxp-agent/1f9e4f52cc5ab1e40f9e2b82c3e644b30c645a97/artifacts/?C=M&O=D