### PR TITLE
(PA-5906) Add macos14 arm definition 7.x

### DIFF
--- a/configs/platforms/osx-14-arm64.rb
+++ b/configs/platforms/osx-14-arm64.rb
@@ -1,0 +1,4 @@
+platform 'osx-14-arm64' do |plat|
+  plat.inherit_from_default
+  plat.output_dir File.join('apple', '14', 'puppet7', 'arm64')
+end


### PR DESCRIPTION
Add MacOS14 ARM platform definition 

[Vanagon Generic builder](https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/1341/)