### PR TITLE
(PA-5905) Add macOS 14 (ARM) platform definition to pxp-agent-vanagon…

### DIFF
--- a/configs/platforms/osx-14-arm64.rb
+++ b/configs/platforms/osx-14-arm64.rb
@@ -1,0 +1,3 @@
+platform 'osx-14-arm64' do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
…-main

vanagon generic build: https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging-ship-repos_generic-builder/lastSuccessfulBuild/

Artifacts: https://builds.delivery.puppetlabs.net/pxp-agent/cf7e422802a12ea4aad0aaf33adc5a0cf4e1c236/artifacts/