### PR TITLE
(PA-6002) Add SLES-11 (Intel) support

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -38,7 +38,7 @@ component 'cpp-hocon' do |pkg, settings, platform|
 
     cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/ ||
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/ ||
         platform.is_aix?
     toolchain = '-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake'
     cmake = '/opt/pl-build-tools/bin/cmake'

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -50,7 +50,7 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
 
     cmake = 'C:/ProgramData/chocolatey/bin/cmake.exe -G "MinGW Makefiles"'
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
     # use default that is pl-build-tools
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -16,10 +16,10 @@ component 'leatherman' do |pkg, settings, platform|
   elsif platform.is_windows?
     pkg.build_requires 'cmake'
     pkg.build_requires "pl-gettext-#{platform.architecture}"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
     pkg.build_requires 'pl-cmake'
     pkg.build_requires 'pl-gettext'
-    pkg.build_requires 'runtime'
+    pkg.build_requires 'runtime' unless platform.name =~ /sles-11/
   end
 
   pkg.build_requires 'puppet-runtime' # Provides curl and ruby
@@ -77,7 +77,7 @@ component 'leatherman' do |pkg, settings, platform|
 
     # Use environment variable set in environment.bat to find locale files
     leatherman_locale_var = "-DLEATHERMAN_LOCALE_VAR='PUPPET_DIR' -DLEATHERMAN_LOCALE_INSTALL='share/locale'"
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/ ||
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/ ||
         platform.is_aix?
     toolchain = '-DCMAKE_TOOLCHAIN_FILE=/opt/pl-build-tools/pl-build-toolchain.cmake'
     cmake = '/opt/pl-build-tools/bin/cmake'

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -66,7 +66,7 @@ component 'pxp-agent' do |pkg, settings, platform|
     toolchain = "-DCMAKE_TOOLCHAIN_FILE=#{settings[:tools_root]}/pl-build-toolchain.cmake"
     special_flags += ' -DDYNAMICBASE=OFF' if platform.name =~ /windowsfips-2012r2/
 
-  elsif platform.name =~ /el-[67]|redhatfips-7|sles-12|ubuntu-18.04-amd64/
+  elsif platform.name =~ /el-[67]|redhatfips-7|sles-1[12]|ubuntu-18.04-amd64/
     # use default that is pl-build-tools
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools

--- a/configs/platforms/sles-11-x86_64.rb
+++ b/configs/platforms/sles-11-x86_64.rb
@@ -1,0 +1,24 @@
+platform "sles-11-x86_64" do |plat|
+  plat.servicedir "/etc/init.d"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "sysv"
+
+  plat.add_build_repository "http://osmirror.delivery.puppetlabs.net/sles-11-deps-x86_64/sles-11-deps-x86_64.repo"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/sles/11/x86_64/pl-build-tools-sles-11-x86_64.repo"
+  packages = %w[
+    aaa_base
+    libbz2-devel
+    make
+    pkgconfig
+    pl-autotools
+    pl-cmake
+    readline-devel
+    rsync
+    zlib-devel
+  ]
+  plat.install_build_dependencies_with "zypper -n --no-gpg-checks install -y"
+  plat.provision_with("zypper -n --no-gpg-checks install -y #{packages.join(' ')}")
+  plat.provision_with("zypper install -y --oldpackage pl-gcc=4.8.2-1")
+  plat.provision_with "zypper install -y --oldpackage pl-cmake-3.2.3-13.sles11.x86_64"
+  plat.vmpooler_template "sles-11-x86_64"
+end


### PR DESCRIPTION
 - Add SLES-11 (Intel) platform definition file
 - SLES-11 uses pl-autotools instead of automake and autoconf since puppet7 uses ruby 2 which is not compatible with the supported version of autoconf and automake for SLES-11.
 - Make cpp-pcp-client, leatherman and pxp-agent components to use the default pl-build-tools.
 - SLES-11 does not require the runtime component since it only adds pl-gcc for it which we already do in its platform definition file.
 - Due to compatibility reasons pl-gcc and pl-cmake have been manually downgraded in the platform definition file.