### PR TITLE
Update checks action

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -9,24 +9,18 @@ on:
 
 jobs:
   checks:
-    name: ${{ matrix.cfg.check }}
-    strategy:
-      matrix:
-        cfg:
-          - {check: rubocop, os: ubuntu-latest, ruby: 2.7}
-          - {check: commits, os: ubuntu-latest, ruby: 2.7}
-
-    runs-on: ${{ matrix.cfg.os }}
+    name: Rubocop check
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install ruby version ${{ matrix.cfg.ruby }}
+      - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.cfg.ruby }}
+          ruby-version: '3.0'
 
       - name: Install bundler and gems
         run: |
@@ -34,6 +28,6 @@ jobs:
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 
-      - name: Run ${{ matrix.cfg.check }} check
-        run: bundle exec rake ${{ matrix.cfg.check }}
+      - name: Run Rubocop check
+        run: bundle exec rake rubocop
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - '.git/**/*'
     - 'bin/*'
     - 'output/**/*'
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 
 Layout/LineLength:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'json'
 gem 'octokit'
 gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.105')
 gem 'rake'
-gem 'rubocop', '~> 1.5.2'
+gem 'rubocop', '~> 1.5'
 gem 'vanagon', *location_for(ENV['VANAGON_LOCATION'] || '~> 0.24')
 
 eval_gemfile("#{__FILE__}.local") if File.exist?("#{__FILE__}.local")

--- a/Rakefile
+++ b/Rakefile
@@ -12,31 +12,3 @@ task(:rubocop) do
   exit_code = cli.run(%w[--display-cop-names --format simple])
   raise 'RuboCop detected offenses' if exit_code != 0
 end
-
-desc 'verify that commit messages match CONTRIBUTING.md requirements'
-task(:commits) do
-  commit_range = 'HEAD^..HEAD'
-  `git log --no-merges --pretty=%s #{commit_range}`.each_line do |commit_summary|
-    error_message = <<~HEREDOC
-      \n\n\n\tThis commit summary didn't match CONTRIBUTING.md guidelines:\n \
-      \n\t\t#{commit_summary}\n \
-      \tThe commit summary (i.e. the first line of the commit message) should start with one of:\n  \
-      \t\t(docs)\n \
-      \t\t(maint)\n \
-      \t\t(packaging)\n \
-      \t\t(<ANY PUBLIC JIRA TICKET>)\n \
-      \n\tThis test for the commit summary is case-insensitive.\n\n\n
-    HEREDOC
-
-    next unless /^\((maint|doc|docs|packaging|pa-\d+)\)|revert|bumping|merge|promoting/i.match(commit_summary).nil?
-
-    ticket = commit_summary.match(/^\(([[:alpha:]]+-[[:digit:]]+)\).*/)
-    raise error_message if ticket.nil?
-
-    require 'net/http'
-    require 'uri'
-    uri = URI.parse("https://tickets.puppetlabs.com/browse/#{ticket[1]}")
-    response = Net::HTTP.get_response(uri)
-    raise error_message if response.code != '200'
-  end
-end

--- a/configs/components/puppet-runtime.rb
+++ b/configs/components/puppet-runtime.rb
@@ -20,7 +20,7 @@ component 'puppet-runtime' do |pkg, settings, platform|
                       # so cmd.exe was not working as expected.
                       [
                         "gunzip -c #{tarball_name} | tar -k -C /cygdrive/c/ -xf -",
-                        "chmod 755 #{settings[:bindir].sub(/C:/, '/cygdrive/c')}/*"
+                        "chmod 755 #{settings[:bindir].sub('C:', '/cygdrive/c')}/*"
                       ]
                     elsif platform.is_macos?
                       # We can't untar into '/' because of SIP on macOS; Just copy the contents

--- a/configs/platforms/solaris-10-i386.rb
+++ b/configs/platforms/solaris-10-i386.rb
@@ -18,7 +18,7 @@ platform "solaris-10-i386" do |plat|
 # please see man -s 4 admin for details about this file:
 # http://www.opensolarisforum.org/man/man4/admin.html
 #
-# The key thing we don\'t want to prompt for are conflicting files.
+# The key thing we don't want to prompt for are conflicting files.
 # The other nocheck settings are mostly defensive to prevent prompts
 # We _do_ want to check for available free space and abort if there is
 # not enough
@@ -32,7 +32,7 @@ runlevel=nocheck
 # Do not bother checking package dependencies (We take care of this)
 idepend=nocheck
 rdepend=nocheck
-# DO check for available free space and abort if there isn\'t enough
+# DO check for available free space and abort if there isn't enough
 space=quit
 # Do not check for setuid files.
 setuid=nocheck

--- a/configs/platforms/solaris-10-sparc.rb
+++ b/configs/platforms/solaris-10-sparc.rb
@@ -22,7 +22,7 @@ platform "solaris-10-sparc" do |plat|
 # please see man -s 4 admin for details about this file:
 # http://www.opensolarisforum.org/man/man4/admin.html
 #
-# The key thing we don\'t want to prompt for are conflicting files.
+# The key thing we don't want to prompt for are conflicting files.
 # The other nocheck settings are mostly defensive to prevent prompts
 # We _do_ want to check for available free space and abort if there is
 # not enough
@@ -36,7 +36,7 @@ runlevel=nocheck
 # Do not bother checking package dependencies (We take care of this)
 idepend=nocheck
 rdepend=nocheck
-# DO check for available free space and abort if there isn\'t enough
+# DO check for available free space and abort if there isn't enough
 space=quit
 # Do not check for setuid files.
 setuid=nocheck

--- a/configs/platforms/solaris-11-sparc.rb
+++ b/configs/platforms/solaris-11-sparc.rb
@@ -14,7 +14,7 @@ platform("solaris-11-sparc", override_name: true) do |plat|
 # please see man -s 4 admin for details about this file:
 # http://www.opensolarisforum.org/man/man4/admin.html
 #
-# The key thing we don\'t want to prompt for are conflicting files.
+# The key thing we don't want to prompt for are conflicting files.
 # The other nocheck settings are mostly defensive to prevent prompts
 # We _do_ want to check for available free space and abort if there is
 # not enough
@@ -28,7 +28,7 @@ runlevel=nocheck
 # Do not bother checking package dependencies (We take care of this)
 idepend=nocheck
 rdepend=nocheck
-# DO check for available free space and abort if there isn\'t enough
+# DO check for available free space and abort if there isn't enough
 space=quit
 # Do not check for setuid files.
 setuid=nocheck


### PR DESCRIPTION
Recently, the checks action began failing because a newer version of Bundler (2.5.0) removed support for Ruby 2.6 and 2.7. Because the checks action runs on Ruby 2.7, the action started to fail.

This commit:
- Updates the Ruby version from 2.7 to 3.0.
- Unpins Rubocop from a three-year-old verison.
- Updates Rubocop's TargetRubyVersion from 2.4 to 2.6.
- Addresses minor style offenses found by the updated Rubocop.
- Removes the commit summary check, as Puppet no longer has a public Jira instance.