### PR TITLE
(PA-6262) Add Amazon Linux2 platform definition to pxp-agent-vanagon-main

### DIFF
--- a/configs/platforms/amazon-7-aarch64.rb
+++ b/configs/platforms/amazon-7-aarch64.rb
@@ -1,0 +1,3 @@
+platform "amazon-7-aarch64" do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
Build: [amazon-7-aarch64](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=amazon-7-aarch64,SLAVE_LABEL=k8s-worker/2919/consoleFull)
[artifacts](https://builds.delivery.puppetlabs.net/pxp-agent/e1f258d30329ae8887e4f0555ceac2f6c73c5e8e/artifacts/)