### PR TITLE
(PA-6263) Add amazon linux2 to pxp-agent 7.x and bump cmake

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -46,10 +46,14 @@ component 'cpp-hocon' do |pkg, settings, platform|
     # These platforms use the default OS toolchain, rather than pl-build-tools
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment 'LDFLAGS', settings[:ldflags]
-    cmake = 'cmake'
     toolchain = ''
     boost_static_flag = '-DBOOST_STATIC=OFF'
     special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
+    cmake = if platform.name =~ /amazon-7-aarch64/
+              '/usr/bin/cmake3'
+            else
+              'cmake'
+            end
   end
 
   # Until we build our own gettext packages, disable using locales.

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -56,10 +56,14 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
     # These platforms use the default OS toolchain, rather than pl-build-tools
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment 'LDFLAGS', settings[:ldflags]
-    cmake = 'cmake'
     toolchain = ''
     platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wimplicit-fallthrough=0'"
     special_flags = ' -DENABLE_CXX_WERROR=OFF'
+    cmake = if platform.name =~ /amazon-7-aarch64/
+              '/usr/bin/cmake3'
+            else
+              'cmake'
+            end
   end
 
   # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -86,9 +86,13 @@ component 'leatherman' do |pkg, settings, platform|
     # These platforms use the default OS toolchain, rather than pl-build-tools
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment 'LDFLAGS', settings[:ldflags]
-    cmake = 'cmake'
     toolchain = ''
     boost_static_flag = ''
+    cmake = if platform.name =~ /amazon-7-aarch64/
+              '/usr/bin/cmake3'
+            else
+              'cmake'
+            end
 
     # Workaround for hanging leatherman tests (-fno-strict-overflow)
     special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -fno-strict-overflow -Wno-deprecated-declarations' "

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -70,10 +70,14 @@ component 'pxp-agent' do |pkg, settings, platform|
     # use default that is pl-build-tools
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools
-    cmake = 'cmake'
     toolchain = ''
     special_flags += " -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-deprecated -Wimplicit-fallthrough=0' "
     special_flags += ' -DENABLE_CXX_WERROR=OFF ' unless platform.name =~ /sles-15/
+    cmake = if platform.name =~ /amazon-7-aarch64/
+              '/usr/bin/cmake3'
+            else
+              'cmake'
+            end
   end
 
   # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost

--- a/configs/platforms/amazon-7-aarch64.rb
+++ b/configs/platforms/amazon-7-aarch64.rb
@@ -1,0 +1,3 @@
+platform "amazon-7-aarch64" do |plat|
+  plat.inherit_from_default
+end


### PR DESCRIPTION
AL2 platform definition added for 7.x

vanagon generic builder : https://jenkins-platform.delivery.puppetlabs.net/view/vanagon-generic-builder/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/2938/