### PR TITLE
(PA-6262) Bumping up cmake version to 3 for amazon-7-aarch64 main

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -56,10 +56,14 @@ component 'cpp-hocon' do |pkg, settings, platform|
     # These platforms use the default OS toolchain, rather than pl-build-tools
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment 'LDFLAGS', settings[:ldflags]
-    cmake = 'cmake'
     toolchain = ''
     boost_static_flag = '-DBOOST_STATIC=OFF'
     special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
+    cmake = if platform.name =~ /amazon-7-aarch64/
+              '/usr/bin/cmake3'
+            else
+              'cmake'
+            end
   end
 
   # Until we build our own gettext packages, disable using locales.

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -68,10 +68,14 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
     # These platforms use the default OS toolchain, rather than pl-build-tools
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment 'LDFLAGS', settings[:ldflags]
-    cmake = 'cmake'
     toolchain = ''
     platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wimplicit-fallthrough=0'"
     special_flags = ' -DENABLE_CXX_WERROR=OFF'
+    cmake = if platform.name =~ /amazon-7-aarch64/
+              '/usr/bin/cmake3'
+            else
+              'cmake'
+            end
   end
 
   # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -106,12 +106,16 @@ component 'leatherman' do |pkg, settings, platform|
     # These platforms use the default OS toolchain, rather than pl-build-tools
     pkg.environment 'CPPFLAGS', settings[:cppflags]
     pkg.environment 'LDFLAGS', settings[:ldflags]
-    cmake = 'cmake'
     toolchain = ''
     boost_static_flag = ''
 
     # Workaround for hanging leatherman tests (-fno-strict-overflow)
     special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -fno-strict-overflow -Wno-deprecated-declarations' "
+    cmake = if platform.name =~ /amazon-7-aarch64/
+              '/usr/bin/cmake3'
+            else
+              'cmake'
+            end
   end
 
   if platform.is_linux?

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -79,10 +79,14 @@ component 'pxp-agent' do |pkg, settings, platform|
     special_flags += "-DCMAKE_CXX_FLAGS='#{settings[:cflags]}' -DENABLE_CXX_WERROR=OFF"
   else
     # These platforms use the default OS toolchain, rather than pl-build-tools
-    cmake = 'cmake'
     toolchain = ''
     special_flags += " -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-deprecated -Wimplicit-fallthrough=0' "
     special_flags += ' -DENABLE_CXX_WERROR=OFF ' unless platform.name =~ /sles-15/
+    cmake = if platform.name =~ /amazon-7-aarch64/
+              '/usr/bin/cmake3'
+            else
+              'cmake'
+            end
   end
 
   # Boost_NO_BOOST_CMAKE=ON was added while upgrading to boost


### PR DESCRIPTION
In Amazon Linux 2, when we install cmake3, it creates a cmake3 executable instead of cmake. Therefore, in this PR, we're adding a condition specifically for the cmake executable on Amazon Linux 2.

Build [amazon-7-aarch64](https://jenkins-platform.delivery.puppetlabs.net/job/platform_vanagon-generic-builder_vanagon-packaging_generic-builder/BUILD_TARGET=amazon-7-aarch64,SLAVE_LABEL=k8s-worker/2934/consoleFull)

Artifacts [pxp-agent](http://builds.delivery.puppetlabs.net/pxp-agent/550885d5786628c472c477d7da117485e6c21bfb/artifacts/)