### PR TITLE
[Backport 7.x] Rename Amazon 7 to 2

### DIFF
--- a/configs/components/cpp-hocon.rb
+++ b/configs/components/cpp-hocon.rb
@@ -49,7 +49,7 @@ component 'cpp-hocon' do |pkg, settings, platform|
     toolchain = ''
     boost_static_flag = '-DBOOST_STATIC=OFF'
     special_flags = " -DENABLE_CXX_WERROR=OFF -DCMAKE_CXX_FLAGS='#{settings[:cflags]}'"
-    cmake = if platform.name =~ /amazon-7-aarch64/
+    cmake = if platform.name =~ /amazon-2-aarch64/
               '/usr/bin/cmake3'
             else
               'cmake'

--- a/configs/components/cpp-pcp-client.rb
+++ b/configs/components/cpp-pcp-client.rb
@@ -59,7 +59,7 @@ component 'cpp-pcp-client' do |pkg, settings, platform|
     toolchain = ''
     platform_flags = "-DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wimplicit-fallthrough=0'"
     special_flags = ' -DENABLE_CXX_WERROR=OFF'
-    cmake = if platform.name =~ /amazon-7-aarch64/
+    cmake = if platform.name =~ /amazon-2-aarch64/
               '/usr/bin/cmake3'
             else
               'cmake'

--- a/configs/components/leatherman.rb
+++ b/configs/components/leatherman.rb
@@ -88,7 +88,7 @@ component 'leatherman' do |pkg, settings, platform|
     pkg.environment 'LDFLAGS', settings[:ldflags]
     toolchain = ''
     boost_static_flag = ''
-    cmake = if platform.name =~ /amazon-7-aarch64/
+    cmake = if platform.name =~ /amazon-2-aarch64/
               '/usr/bin/cmake3'
             else
               'cmake'

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -73,7 +73,7 @@ component 'pxp-agent' do |pkg, settings, platform|
     toolchain = ''
     special_flags += " -DCMAKE_CXX_FLAGS='#{settings[:cflags]} -Wno-deprecated -Wimplicit-fallthrough=0' "
     special_flags += ' -DENABLE_CXX_WERROR=OFF ' unless platform.name =~ /sles-15/
-    cmake = if platform.name =~ /amazon-7-aarch64/
+    cmake = if platform.name =~ /amazon-2-aarch64/
               '/usr/bin/cmake3'
             else
               'cmake'

--- a/configs/platforms/amazon-2-aarch64.rb
+++ b/configs/platforms/amazon-2-aarch64.rb
@@ -1,0 +1,3 @@
+platform "amazon-2-aarch64" do |plat|
+  plat.inherit_from_default
+end

--- a/configs/platforms/amazon-7-aarch64.rb
+++ b/configs/platforms/amazon-7-aarch64.rb
@@ -1,3 +1,0 @@
-platform "amazon-7-aarch64" do |plat|
-  plat.inherit_from_default
-end


### PR DESCRIPTION
Amazon 7 is an implementation detail, the actual OS is named Amazon 2

(cherry picked from commit 6bf00a03927893aec3a646a661eab79267021434)